### PR TITLE
disable pausing during level over screen

### DIFF
--- a/Assets/Scripts/UI/InGameUIManager.cs
+++ b/Assets/Scripts/UI/InGameUIManager.cs
@@ -207,6 +207,10 @@ public class InGameUIManager : MonoBehaviour
 
     public void OnPauseGame()
     {
+        if(_gameOverUI.activeSelf) {
+            return;
+        }
+        
         OnPauseMenuOpen.Invoke();
         _pauseUI.SetActive(true);
         _gameManager.PauseGame();


### PR DESCRIPTION
## Changes
Disable pausing during level over screen
With pausing removed, aiming during the level over screen no longer occurs

### Known Bugs/Issues

## Testing Scene and Script
Tutorial Room, Living Room, or Kitchen

InGameUIManager.cs

See issues below for steps to reproduce, bugs should no longer occur.

## Issue ticket number/link
#51 #52 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
