### PR TITLE
same weight for all ball colors

### DIFF
--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/BlueBall.asset
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/BlueBall.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: BlueBall
   m_EditorClassIdentifier: 
   color: {fileID: 11400000, guid: 29e19a1c4d33c8a4786ed45a18fdcf21, type: 2}
-  bounciness: 1
+  bounciness: 0.98
   mass: 1
   damageMod: 0.5
   repairMod: 1

--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/GreenBall.asset
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/GreenBall.asset
@@ -13,11 +13,11 @@ MonoBehaviour:
   m_Name: GreenBall
   m_EditorClassIdentifier: 
   color: {fileID: 11400000, guid: b40ea3a328c5556479e00cc115f57182, type: 2}
-  bounciness: 0.5
-  mass: 0.5
+  bounciness: 0.98
+  mass: 1
   damageMod: 0.5
   repairMod: 1
-  massMultiplier: 0.5
+  massMultiplier: 1
   massCap: 5
   scaleMultiplier: 1
   scaleCap: 5

--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/RedBall.asset
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/RedBall.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: RedBall
   m_EditorClassIdentifier: 
   color: {fileID: 11400000, guid: 853307e61ecf1f34cbb7809ce9e09159, type: 2}
-  bounciness: 0.5
-  mass: 2
+  bounciness: 0.98
+  mass: 1
   damageMod: 0.5
   repairMod: 1
   massMultiplier: 1


### PR DESCRIPTION
## Changes
Make all ball colors have the same weight

### Known Bugs/Issues
N/A

## Testing Scene and Script
Testing on any scene should have the ball weights renormalized

YarnAttributesSO.cs

## Issue ticket number/link
#61 , #50 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
