### PR TITLE
Light Easy Build Setup

### DIFF
--- a/Assets/SuperUnityBuild.meta
+++ b/Assets/SuperUnityBuild.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 946c8a37a95654e68b5655a935cf5ac3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SuperUnityBuild/BuildConstants.cs
+++ b/Assets/SuperUnityBuild/BuildConstants.cs
@@ -8,7 +8,6 @@ namespace SuperUnityBuild.Generated
     {
         None,
         Release,
-        Prototyping,
     }
 
     public enum Platform
@@ -34,17 +33,19 @@ namespace SuperUnityBuild.Generated
     public enum Distribution
     {
         None,
+        windows_x64,
+        macos_universal,
     }
 
     public static class BuildConstants
     {
-        public static readonly DateTime buildDate = new DateTime(638595897315147560);
-        public const string version = "v0.2";
+        public static readonly DateTime buildDate = new DateTime(638596044702178280);
+        public const string version = "v0.1";
         public const ReleaseType releaseType = ReleaseType.Release;
         public const Platform platform = Platform.macOS;
         public const ScriptingBackend scriptingBackend = ScriptingBackend.Mono;
         public const Architecture architecture = Architecture.macOS;
-        public const Distribution distribution = Distribution.None;
+        public const Distribution distribution = Distribution.macos_universal;
     }
 }
 

--- a/Assets/SuperUnityBuild/BuildConstants.cs
+++ b/Assets/SuperUnityBuild/BuildConstants.cs
@@ -1,0 +1,50 @@
+using System;
+
+// This file is auto-generated. Do not modify or move this file.
+
+namespace SuperUnityBuild.Generated
+{
+    public enum ReleaseType
+    {
+        None,
+        Release,
+        Prototyping,
+    }
+
+    public enum Platform
+    {
+        None,
+        PC,
+        macOS,
+    }
+
+    public enum ScriptingBackend
+    {
+        None,
+        Mono,
+    }
+
+    public enum Architecture
+    {
+        None,
+        Windows_x64,
+        macOS,
+    }
+
+    public enum Distribution
+    {
+        None,
+    }
+
+    public static class BuildConstants
+    {
+        public static readonly DateTime buildDate = new DateTime(638595897315147560);
+        public const string version = "v0.2";
+        public const ReleaseType releaseType = ReleaseType.Release;
+        public const Platform platform = Platform.macOS;
+        public const ScriptingBackend scriptingBackend = ScriptingBackend.Mono;
+        public const Architecture architecture = Architecture.macOS;
+        public const Distribution distribution = Distribution.None;
+    }
+}
+

--- a/Assets/SuperUnityBuild/BuildConstants.cs.meta
+++ b/Assets/SuperUnityBuild/BuildConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdd897c9b79b34852add28c2ebeef35f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SuperUnityBuild/Editor.meta
+++ b/Assets/SuperUnityBuild/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 510f91025c730492fa9f22bdaed11344
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SuperUnityBuild/Editor/BuildActions.meta
+++ b/Assets/SuperUnityBuild/Editor/BuildActions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58d1263dc3a8e47039e0c00db2215254
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SuperUnityBuild/Settings.meta
+++ b/Assets/SuperUnityBuild/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 178df71ca9d674655a4fa2a170ce961e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SuperUnityBuild/Settings/SuperUnityBuildSettings.asset
+++ b/Assets/SuperUnityBuild/Settings/SuperUnityBuildSettings.asset
@@ -1,0 +1,256 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5072664549582472715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97d88f7d353534a4fbdeb11196057db7, type: 3}
+  m_Name: UploadItch
+  m_EditorClassIdentifier: 
+  actionType: 1
+  actionName: UploadItch
+  note: 
+  actionEnabled: 0
+  configureEditor: 0
+  filter:
+    condition: 0
+    clauses: []
+  pathToButlerExe: 
+  nameOfItchUser: 
+  nameOfItchGame: 
+  useGeneratedBuildVersion: 1
+  channelName: $PLATFORM-$ARCHITECTURE
+  showUploadProgress: 1
+  itchChannelOverride: 
+--- !u!114 &-3613426804341958447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54626104f6c7de94f9976e1672abc45b, type: 3}
+  m_Name: FolderOperation
+  m_EditorClassIdentifier: 
+  actionType: 1
+  actionName: FolderOperation
+  note: Separate BurstDebugInformation
+  actionEnabled: 1
+  configureEditor: 0
+  filter:
+    condition: 0
+    clauses: []
+  inputPath: $BUILDPATH/$PRODUCT_NAME_BurstDebugInformation_DoNotShip
+  outputPath: $BASEPATH/DoNotShip/$VERSION-$ARCHITECTURE-BurstDebugInformation
+  operation: 0
+--- !u!114 &-827903316222987588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de0f7a04940394844a505e73c3eb8cec, type: 3}
+  m_Name: ZipFileOperation
+  m_EditorClassIdentifier: 
+  actionType: 1
+  actionName: ZipFileOperation
+  note: Zip build files
+  actionEnabled: 0
+  configureEditor: 0
+  filter:
+    condition: 0
+    clauses: []
+  inputPath: $BUILDPATH
+  outputPath: $BASEPATH
+  outputFileName: $PRODUCT_NAME-$PLATFORM-$VERSION.zip
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d5886119a5c7b34d8872ab527ca3e1b, type: 3}
+  m_Name: SuperUnityBuildSettings
+  m_EditorClassIdentifier: 
+  _basicSettings:
+    baseBuildFolder: Builds
+    buildPath: $VERSION/$ARCHITECTURE-$SCRIPTING_BACKEND
+    openFolderPostBuild: 1
+    constantsFileLocation: Assets/SuperUnityBuild
+  _productParameters:
+    buildCounter: 0
+    buildVersion: v0.2
+    versionTemplate: v0.$BUILD
+    autoGenerate: 1
+    syncWithPlayerSettings: 0
+  _releaseTypeList:
+    releaseTypes:
+    - typeName: Release
+      bundleIdentifier: com.Blue-Square-Legion.Keito
+      companyName: Blue Square Legion
+      productName: Keito
+      syncAppNameWithProduct: 1
+      appBuildName: Keito
+      buildOptions: 524288
+      customDefines: 
+      sceneList:
+        releaseScenes:
+        - fileGUID: 2c261f7e4eb37425f8b0ed8d30c02c01
+          sceneActive: 1
+        - fileGUID: be72b19073b614747a83a0477359223e
+          sceneActive: 1
+        - fileGUID: 8c9cfa26abfee488c85f1582747f6a02
+          sceneActive: 1
+        - fileGUID: a2cb2ea7e674c40d5965af2ab84c4168
+          sceneActive: 1
+  _platformList:
+    platforms:
+    - {fileID: 5018678257089528286}
+    - {fileID: 741060016363233176}
+  _projectConfigurations:
+    configSet:
+      _Buckets: 010000000300000006000000ffffffffffffffff0200000005000000
+      _HashCodes: f7e46342878a7279510e9f59d03dcd4dceee4e3995803a142d6dfd48
+      _Next: ffffffffffffffffffffffffffffffffffffffff0400000000000000
+      _Count: 7
+      _Version: 7
+      _FreeList: -1
+      _FreeCount: 0
+      _Keys:
+      - Release/PC/Windows x64 (App)/Mono
+      - Release/PC/Windows x64 (App)
+      - Release/PC
+      - Release/macOS/macOS (Universal,App)/Mono
+      - Release/macOS/macOS (Universal,App)
+      - Release/macOS
+      - Release
+      _Values:
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys:
+        - Release/PC/Windows x64 (App)/Mono
+      - enabled: 1
+        childKeys:
+        - Release/PC/Windows x64 (App)
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys:
+        - Release/macOS/macOS (Universal,App)/Mono
+      - enabled: 1
+        childKeys:
+        - Release/macOS/macOS (Universal,App)
+      - enabled: 1
+        childKeys:
+        - Release/PC
+        - Release/macOS
+    showViewOptions: 0
+    showConfigs: 0
+    showBuildInfo: 0
+    hideDisabled: 0
+    treeView: 0
+    selectedKeyChain: Release/macOS/macOS (Universal,App)/Mono
+  _preBuildActions:
+    buildActions: []
+  _postBuildActions:
+    buildActions:
+    - {fileID: -3613426804341958447}
+    - {fileID: -827903316222987588}
+    - {fileID: -5072664549582472715}
+--- !u!114 &741060016363233176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d962d142a259c394da2bdb301b72eeb5, type: 3}
+  m_Name: macOS
+  m_EditorClassIdentifier: 
+  enabled: 1
+  distributionList:
+    distributions: []
+  architectures:
+  - target: 2
+    name: macOS
+    enabled: 1
+    binaryNameFormat: '{0}.app'
+  variants:
+  - variantName: macOS Architecture
+    selectedIndex: 2
+    values:
+    - Intelx64
+    - Apple Silicon
+    - Universal
+    isFlag: 0
+  - variantName: Build Output
+    selectedIndex: 0
+    values:
+    - App
+    - Xcode Project
+    isFlag: 0
+  scriptingBackends:
+  - scriptingImplementation: 0
+    name: Mono
+    enabled: 1
+  - scriptingImplementation: 1
+    name: IL2CPP
+    enabled: 0
+  platformName: macOS
+  targetGroup: 1
+--- !u!114 &5018678257089528286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2786f6b2301a94f4288672ff5305244c, type: 3}
+  m_Name: PC
+  m_EditorClassIdentifier: 
+  enabled: 1
+  distributionList:
+    distributions: []
+  architectures:
+  - target: 5
+    name: Windows x86
+    enabled: 0
+    binaryNameFormat: '{0}.exe'
+  - target: 19
+    name: Windows x64
+    enabled: 1
+    binaryNameFormat: '{0}.exe'
+  variants:
+  - variantName: Build Output
+    selectedIndex: 0
+    values:
+    - App
+    - Visual Studio Solution
+    isFlag: 0
+  scriptingBackends:
+  - scriptingImplementation: 0
+    name: Mono
+    enabled: 1
+  - scriptingImplementation: 1
+    name: IL2CPP
+    enabled: 0
+  platformName: PC
+  targetGroup: 1

--- a/Assets/SuperUnityBuild/Settings/SuperUnityBuildSettings.asset
+++ b/Assets/SuperUnityBuild/Settings/SuperUnityBuildSettings.asset
@@ -1,5 +1,32 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6706168606254285045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97d88f7d353534a4fbdeb11196057db7, type: 3}
+  m_Name: UploadItch
+  m_EditorClassIdentifier: 
+  actionType: 1
+  actionName: UploadItch
+  note: 
+  actionEnabled: 0
+  configureEditor: 0
+  filter:
+    condition: 0
+    clauses: []
+  pathToButlerExe: /Users/secondary/Applications/Shell/butler-darwin-amd64/butler
+  nameOfItchUser: sam325
+  nameOfItchGame: keito-game
+  useGeneratedBuildVersion: 1
+  channelName: $PLATFORM-$ARCHITECTURE
+  showUploadProgress: 1
+  itchChannelOverride: 
 --- !u!114 &-5072664549582472715
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -21,8 +48,8 @@ MonoBehaviour:
     condition: 0
     clauses: []
   pathToButlerExe: 
-  nameOfItchUser: 
-  nameOfItchGame: 
+  nameOfItchUser: sam325
+  nameOfItchGame: keito-game
   useGeneratedBuildVersion: 1
   channelName: $PLATFORM-$ARCHITECTURE
   showUploadProgress: 1
@@ -50,29 +77,6 @@ MonoBehaviour:
   inputPath: $BUILDPATH/$PRODUCT_NAME_BurstDebugInformation_DoNotShip
   outputPath: $BASEPATH/DoNotShip/$VERSION-$ARCHITECTURE-BurstDebugInformation
   operation: 0
---- !u!114 &-827903316222987588
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: de0f7a04940394844a505e73c3eb8cec, type: 3}
-  m_Name: ZipFileOperation
-  m_EditorClassIdentifier: 
-  actionType: 1
-  actionName: ZipFileOperation
-  note: Zip build files
-  actionEnabled: 0
-  configureEditor: 0
-  filter:
-    condition: 0
-    clauses: []
-  inputPath: $BUILDPATH
-  outputPath: $BASEPATH
-  outputFileName: $PRODUCT_NAME-$PLATFORM-$VERSION.zip
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -92,7 +96,7 @@ MonoBehaviour:
     constantsFileLocation: Assets/SuperUnityBuild
   _productParameters:
     buildCounter: 0
-    buildVersion: v0.2
+    buildVersion: v0.1
     versionTemplate: v0.$BUILD
     autoGenerate: 1
     syncWithPlayerSettings: 0
@@ -122,24 +126,37 @@ MonoBehaviour:
     - {fileID: 741060016363233176}
   _projectConfigurations:
     configSet:
-      _Buckets: 010000000300000006000000ffffffffffffffff0200000005000000
-      _HashCodes: f7e46342878a7279510e9f59d03dcd4dceee4e3995803a142d6dfd48
-      _Next: ffffffffffffffffffffffffffffffffffffffff0400000000000000
-      _Count: 7
-      _Version: 7
+      _Buckets: ffffffff06000000ffffffff08000000ffffffffffffffffffffffff0500000004000000ffffffffffffffff01000000ffffffffffffffffffffffff07000000ffffffff
+      _HashCodes: c683c44ef7e46342878a7279510e9f5956fc3370d03dcd4dceee4e3995803a142d6dfd480000000000000000000000000000000000000000000000000000000000000000
+      _Next: ffffffffffffffffffffffffffffffff00000000ffffffffffffffff02000000030000000000000000000000000000000000000000000000000000000000000000000000
+      _Count: 9
+      _Version: 9
       _FreeList: -1
       _FreeCount: 0
       _Keys:
+      - Release/PC/Windows x64 (App)/Mono/windows-x64
       - Release/PC/Windows x64 (App)/Mono
       - Release/PC/Windows x64 (App)
       - Release/PC
+      - Release/macOS/macOS (Universal,App)/Mono/macos-universal
       - Release/macOS/macOS (Universal,App)/Mono
       - Release/macOS/macOS (Universal,App)
       - Release/macOS
       - Release
+      - 
+      - 
+      - 
+      - 
+      - 
+      - 
+      - 
+      - 
       _Values:
       - enabled: 1
         childKeys: []
+      - enabled: 1
+        childKeys:
+        - Release/PC/Windows x64 (App)/Mono/windows-x64
       - enabled: 1
         childKeys:
         - Release/PC/Windows x64 (App)/Mono
@@ -150,6 +167,9 @@ MonoBehaviour:
         childKeys: []
       - enabled: 1
         childKeys:
+        - Release/macOS/macOS (Universal,App)/Mono/macos-universal
+      - enabled: 1
+        childKeys:
         - Release/macOS/macOS (Universal,App)/Mono
       - enabled: 1
         childKeys:
@@ -158,19 +178,35 @@ MonoBehaviour:
         childKeys:
         - Release/PC
         - Release/macOS
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
+      - enabled: 1
+        childKeys: []
     showViewOptions: 0
     showConfigs: 0
     showBuildInfo: 0
     hideDisabled: 0
     treeView: 0
-    selectedKeyChain: Release/macOS/macOS (Universal,App)/Mono
+    selectedKeyChain: Release/macOS/macOS (Universal,App)/Mono/macos-universal
   _preBuildActions:
     buildActions: []
   _postBuildActions:
     buildActions:
     - {fileID: -3613426804341958447}
-    - {fileID: -827903316222987588}
-    - {fileID: -5072664549582472715}
+    - {fileID: 3638567506685254133}
+    - {fileID: -6706168606254285045}
 --- !u!114 &741060016363233176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -185,7 +221,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enabled: 1
   distributionList:
-    distributions: []
+    distributions:
+    - distributionName: macos-universal
+      enabled: 1
   architectures:
   - target: 2
     name: macOS
@@ -214,6 +252,29 @@ MonoBehaviour:
     enabled: 0
   platformName: macOS
   targetGroup: 1
+--- !u!114 &3638567506685254133
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c7f7586f72aa4eaeadcc71412569451, type: 3}
+  m_Name: BetterZipFileOperation
+  m_EditorClassIdentifier: 
+  actionType: 1
+  actionName: BetterZipFileOperation
+  note: Zip files for backup
+  actionEnabled: 1
+  configureEditor: 0
+  filter:
+    condition: 0
+    clauses: []
+  inputPath: $BUILDPATH
+  outputPath: $BASEPATH
+  outputFileName: $PRODUCT_NAME-$PLATFORM.zip
 --- !u!114 &5018678257089528286
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -228,7 +289,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enabled: 1
   distributionList:
-    distributions: []
+    distributions:
+    - distributionName: windows-x64
+      enabled: 1
   architectures:
   - target: 5
     name: Windows x86

--- a/Assets/SuperUnityBuild/Settings/SuperUnityBuildSettings.asset.meta
+++ b/Assets/SuperUnityBuild/Settings/SuperUnityBuildSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 626379f06f32b420d96cfbb7944edd13
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Utility.meta
+++ b/Assets/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 19e380d70fe9d427ba148ed595b86999
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Utility/Editor.meta
+++ b/Assets/Utility/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: deebdab4fe1844d89810e4cf0118756d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Utility/Editor/BetterZipFileOperation.cs
+++ b/Assets/Utility/Editor/BetterZipFileOperation.cs
@@ -1,0 +1,81 @@
+/// Adapted from https://github.com/cosformula/buildactions/blob/3864e2bb709a5ff154c4c513c4d17abaf22f215b/Editor/ZipFile/ZipFileOperation.cs
+/// which is under the MIT License, see https://github.com/cosformula/buildactions/blob/3864e2bb709a5ff154c4c513c4d17abaf22f215b/LICENSE.md
+using SuperUnityBuild.BuildTool;
+using System;
+using System.IO;
+using UnityEngine;
+using System.IO.Compression;
+
+namespace Keito.BuildActions
+{
+    public class BetterZipFileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
+    {
+        public string inputPath = "$BUILDPATH";
+        public string outputPath = "$BUILDPATH";
+        public string outputFileName = "$PRODUCT_NAME-$RELEASE_TYPE-$YEAR_$MONTH_$DAY.zip";
+
+        public override void PerBuildExecute(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture, BuildScriptingBackend scriptingBackend, BuildDistribution distribution, DateTime buildTime, ref UnityEditor.BuildOptions options, string configKey, string buildPath)
+        {
+            string combinedOutputPath = Path.Combine(outputPath, outputFileName);
+            string resolvedOutputPath = BuildAction.ResolvePerBuildExecuteTokens(combinedOutputPath, releaseType, platform, architecture, scriptingBackend, distribution, buildTime, buildPath);
+
+            string resolvedInputPath = BuildAction.ResolvePerBuildExecuteTokens(inputPath, releaseType, platform, architecture, scriptingBackend, distribution, buildTime, buildPath);
+
+            if (!resolvedOutputPath.EndsWith(".zip"))
+            {
+                resolvedOutputPath += ".zip";
+            }
+
+            PerformZip(Path.GetFullPath(resolvedInputPath), Path.GetFullPath(resolvedOutputPath), platform);
+        }
+
+        private void PerformZip(string inputPath, string outputPath, BuildPlatform platform)
+        {
+            try
+            {
+                if (!Directory.Exists(inputPath))
+                {
+                    BuildNotificationList.instance.AddNotification(new BuildNotification(
+                        BuildNotification.Category.Error,
+                        "Zip Operation Failed.", string.Format("Input path does not exist: {0}", inputPath),
+                        true, null));
+                    return;
+                }
+
+                // Make sure that all parent directories in path are already created.
+                string parentPath = Path.GetDirectoryName(outputPath);
+                if (!Directory.Exists(parentPath))
+                {
+                    Directory.CreateDirectory(parentPath);
+                }
+
+                // Delete old file if it exists.
+                if (File.Exists(outputPath))
+                {
+                    File.Delete(outputPath);
+                }
+                System.IO.Compression.ZipFile.CreateFromDirectory(inputPath, outputPath);
+                // MacOS specific to keep permissions after zip 
+                if (platform.platformName == "macOS")
+                {
+                    // Re-open zip for updating
+                    using (var zipArchive = System.IO.Compression.ZipFile.Open(outputPath, ZipArchiveMode.Update))
+                    {
+                        foreach (var entry in zipArchive.Entries)
+                        {
+                            // Find MacOS executable and set it to be executable
+                            if (entry.FullName.Contains("Contents/MacOS"))
+                            {
+                                entry.ExternalAttributes = 0755;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError(ex.ToString());
+            }
+        }
+    }
+}

--- a/Assets/Utility/Editor/BetterZipFileOperation.cs.meta
+++ b/Assets/Utility/Editor/BetterZipFileOperation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c7f7586f72aa4eaeadcc71412569451
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -139,7 +139,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0
+  bundleVersion: v0.1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -162,11 +162,11 @@ PlayerSettings:
   applicationIdentifier:
     Standalone: com.Blue-Square-Legion.Keito
   buildNumber:
-    Standalone: 0
-    iPhone: 0
+    Standalone: 17
+    iPhone: 17
     tvOS: 0
-  overrideDefaultApplicationIdentifier: 0
-  AndroidBundleVersionCode: 1
+  overrideDefaultApplicationIdentifier: 1
+  AndroidBundleVersionCode: 18
   AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
@@ -785,7 +785,7 @@ PlayerSettings:
     PS4: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
     PS5: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
     Stadia: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
-    Standalone: UNITY_PIPELINE_URP;UNITY_POST_PROCESSING_STACK_V2;DOTWEEN;DOTWEEN_ENABLED
+    Standalone: BUILD_TYPE_RELEASE;BUILD_PLATFORM_MACOS;BUILD_ARCH_MACOS;BUILD_BACKEND_MONO;BUILD_DIST_MACOS_UNIVERSAL;UNITY_PIPELINE_URP;UNITY_POST_PROCESSING_STACK_V2;DOTWEEN;DOTWEEN_ENABLED
     WebGL: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
     Windows Store Apps: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
     XboxOne: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
@@ -793,7 +793,8 @@ PlayerSettings:
     tvOS: UNITY_POST_PROCESSING_STACK_V2;DOTWEEN
   additionalCompilerArguments: {}
   platformArchitecture: {}
-  scriptingBackend: {}
+  scriptingBackend:
+    Standalone: 0
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}


### PR DESCRIPTION
## Changes
- Add default settings for SuperUnityBuild build tool. Will do the following:
    - build Keito for MacOS (universal binary) and Windows (64-bit only). 
    - After build, will move the BurstDebugInfo to separate folder
    - Then, zip the build files
    - Finally, if active, will push new build to Itch.io
- Create a better version of zip operation to keep MacOS application as executable after zip. 

### Known Bugs/Issues
- Make sure Build Modules for Windows (Mono) and MacOS (Mono) are added to your Unity editor
- Less bug, more thing to consider, when uploading to Itch, the Butler application must have the API key of a user with Admin access.

## Testing Scene and Script
- Open SuperBuildTool tab (under `Window` in menubar), check and modify settings (object `SuperUnityBuildSettings`) from there, button "Perform All Enabled Build" will run build pipeline

## Issue ticket number/link
<!--- Provide a link or ticket number for an associated issue -->

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] Make sure I am merging my features into the `develop` branch
- [X] I have notified the other members of the programming team that my task is ready to review
