### PR TITLE
sticky balls detach if enough force

### DIFF
--- a/Assets/Scripts/Ball/IYarnBallEffect.cs
+++ b/Assets/Scripts/Ball/IYarnBallEffect.cs
@@ -24,13 +24,13 @@ public class ExcessiveForceEffect : IYarnBallEffect
 
 public class StickyEffect : IYarnBallEffect
 {
-    private Transform ball1;
-    private Transform ball2;
+    private Transform stickyBall;
+    private Transform otherBall;
 
-    public StickyEffect(Transform ball1, Transform ball2)
+    public StickyEffect(Transform stickyBall, Transform otherBall)
     {
-        this.ball1 = ball1;
-        this.ball2 = ball2;
+        this.stickyBall = stickyBall;
+        this.otherBall = otherBall;
     }
 
     public void CreateEffect()
@@ -42,14 +42,14 @@ public class StickyEffect : IYarnBallEffect
     {
         Debug.Log("Applying Sticky Effect");
 
-        Rigidbody rb1 = ball1.GetComponent<Rigidbody>();
-        Rigidbody rb2 = ball2.GetComponent<Rigidbody>();
+        Rigidbody rb1 = stickyBall.GetComponent<Rigidbody>();
+        Rigidbody rb2 = otherBall.GetComponent<Rigidbody>();
 
         if (rb1 != null && rb2 != null)
         {
-            FixedJoint joint = ball1.gameObject.AddComponent<FixedJoint>();
+            FixedJoint joint = stickyBall.gameObject.AddComponent<FixedJoint>();
             joint.connectedBody = rb2;
-            joint.breakForce = float.PositiveInfinity;
+            joint.breakForce = 1000.0f;
         }
     }
 }


### PR DESCRIPTION
## Changes
Make it so the sticky balls detach if the force is high enough. This should resolve the endlessly spinning/breakdancing balls.

### Known Bugs/Issues
"the trade off is that the sticky balls will sometimes detach if the force is too great (this way the crazy spinning doesn't happen). But I think this is acceptable since the balls are only meant to be sticky and not inseparable"
"the numbers can always be changed where the tradeoff is higher stickiness = more likely for crazy spinning, lower stickiness = less chance for spinning but easier to break off"
- there is sometimes a small but visible gap between balls that are stuck together

## Testing Scene and Script
Living Room or Kitchen

IYarnBallEffect.cs

## Issue ticket number/link
#63 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
