### PR TITLE
lighter balls attached to sticky

### DIFF
--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/StickyEffect.asset
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/StickyEffect.asset
@@ -12,3 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3b260778ef88ba840b4379102d4dd981, type: 3}
   m_Name: StickyEffect
   m_EditorClassIdentifier: 
+  jointBreakForce: 1000
+  massReductionFactor: 0.5

--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/StickyEffectSO.cs
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/StickyEffectSO.cs
@@ -6,7 +6,9 @@ using UnityEngine;
 public class StickyEffectSO : YarnBallEffectSO
 {
     [SerializeField] private float jointBreakForce = 1000.0f;
-    private Transform _stickyTarget;
+    [SerializeField] private float massReductionFactor = 0.5f;
+
+    private Dictionary<Rigidbody, float> originalMasses = new Dictionary<Rigidbody, float>();
 
     public override void CreateEffect(GameObject ball, Transform target = null) { }
 
@@ -19,14 +21,52 @@ public class StickyEffectSO : YarnBallEffectSO
     {
         if (ballRigidbody != null && targetRigidbody != null)
         {
+            if (!originalMasses.ContainsKey(targetRigidbody))
+            {
+                originalMasses[targetRigidbody] = targetRigidbody.mass;
+                targetRigidbody.mass *= massReductionFactor;
+            }
+
             FixedJoint joint = ball.AddComponent<FixedJoint>();
             joint.connectedBody = targetRigidbody;
             joint.breakForce = jointBreakForce;
+            joint.breakTorque = jointBreakForce;
+
             Debug.Log("Applying Sticky Effect to " + ball.name);
+
+            ballRigidbody.gameObject.AddComponent<JointBreakListener>().Initialize(this, targetRigidbody);
         }
         else
         {
             Debug.LogError("Sticky effect cannot be applied: either ballRigidbody or targetRigidbody is missing.");
         }
+    }
+
+    public void RestoreOriginalMass(Rigidbody targetRigidbody)
+    {
+        if (originalMasses.ContainsKey(targetRigidbody))
+        {
+            targetRigidbody.mass = originalMasses[targetRigidbody];
+            originalMasses.Remove(targetRigidbody);
+            Debug.Log("Restored original mass to " + targetRigidbody.gameObject.name);
+        }
+    }
+}
+
+public class JointBreakListener : MonoBehaviour
+{
+    private StickyEffectSO stickyEffect;
+    private Rigidbody attachedRigidbody;
+
+    public void Initialize(StickyEffectSO effect, Rigidbody rb)
+    {
+        stickyEffect = effect;
+        attachedRigidbody = rb;
+    }
+
+    private void OnJointBreak(float breakForce)
+    {
+        stickyEffect.RestoreOriginalMass(attachedRigidbody);
+        Destroy(this);
     }
 }


### PR DESCRIPTION
## Changes
When the balls are attached to a sticky ball, they become lighter by a factor specified in the StickyEffectSO (which can be modified in the inspector). When the balls are detached, their original mass is restored.

### Known Bugs/Issues
When red balls are attached to green balls, their mass is lighter so then they may sometimes apply the excessive force effect if they are hit even if they are not moving. This may require some more playing with the numbers of the velocity threshold or the mass reduction factor, or else redesigning the excessive force effect at a later time.

## Testing Scene and Script
Living Room or Kitchen

## Issue ticket number/link
#82 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
