### PR TITLE
Fixed startup issue of color change effect

### DIFF
--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/ColorChangeEffectSO.cs
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/ColorChangeEffectSO.cs
@@ -10,8 +10,6 @@ public class ColorChangeEffectSO : YarnBallEffectSO
     
     public override void CreateEffect(GameObject ball, Transform target = null) 
     {
-        Debug.Log("Color Change Effect Created");
-
         _handler = ball.GetComponent<ColorChangeEffectHandler>();
         if (_handler == null)
         {

--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/CyanBall.asset
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/CyanBall.asset
@@ -26,4 +26,5 @@ MonoBehaviour:
   acceptableCombinations: []
   collisionEffects:
   - {fileID: 11400000, guid: 2357d8c07e6753f47b26cafe94a57715, type: 2}
-  generalEffects: []
+  launchEffects:
+  - {fileID: 11400000, guid: 2357d8c07e6753f47b26cafe94a57715, type: 2}


### PR DESCRIPTION
The color change effect only start after it collides with another Yarn ball. I fixed it.

## Changes
<!-- Provide a list of high level changes for your work on this Pull Request. -->
Added Color Change Effect in Launch Effects of Yarn Ball Attributes of Cyan Ball

### Known Bugs/Issues

## Testing Scene and Script
<!--- Provide the name of the scene(s) and scripts that the reviewer needs to check to make sure your task is finished -->

## Issue ticket number/link
<!--- Provide a link or ticket number for an associated issue -->

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
