### PR TITLE
Red balls no longer affect themselves on combine

### DIFF
--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/ExcessiveForceEffectSO.cs
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/ExcessiveForceEffectSO.cs
@@ -23,6 +23,13 @@ public class ExcessiveForceEffectSO : YarnBallEffectSO
             return;
         }
 
+        if (targetRigidbody.gameObject.TryGetComponent(out ColorController cc)
+            && cc.Color == ball.GetComponent<ColorController>().Color)
+        {
+            Debug.Log($"Did not apply force; balls are combining.");
+            return;
+        }
+
         if (ballRigidbody.velocity.magnitude > velocityThreshold)
         {
             Vector3 multiplicativeForce = ballRigidbody.velocity * forceMultiplier * -1;


### PR DESCRIPTION
## Changes
Red ball no longer adds excess force to itself.

### Known Bugs/Issues
No new bugs! :D
## Testing Scene and Script
Normal Living Room, ExcessiveForceEffectSO

## Issue ticket number/link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
