### PR TITLE
Pull Request - Jan 03 2025

### DIFF
--- a/Assets/Prefabs/YarnBalls/Yarn Grey Variant.prefab
+++ b/Assets/Prefabs/YarnBalls/Yarn Grey Variant.prefab
@@ -89,7 +89,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8781174676102523480, guid: 6f1991215cd624462896b6ad92f28885, type: 3}
       propertyPath: m_UseGravity
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8981885912593688717, guid: 6f1991215cd624462896b6ad92f28885, type: 3}
       propertyPath: _color

--- a/Assets/Prefabs/YarnBalls/Yarn Purple Variant.prefab
+++ b/Assets/Prefabs/YarnBalls/Yarn Purple Variant.prefab
@@ -79,6 +79,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8781174676102523480, guid: 6f1991215cd624462896b6ad92f28885, type: 3}
+      propertyPath: m_UseGravity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8981885912593688717, guid: 6f1991215cd624462896b6ad92f28885, type: 3}
       propertyPath: _color
       value: 

--- a/Assets/Scripts/ScriptableObjects/YarnAttributes/MagnetEffectHandler.cs
+++ b/Assets/Scripts/ScriptableObjects/YarnAttributes/MagnetEffectHandler.cs
@@ -19,6 +19,8 @@ public class MagnetEffectHandler : MonoBehaviour
         float elapsedTime = 0f;
         GameObject particleObj = Instantiate(particlePrefab, transform);
         particleObj.transform.localScale = new Vector3(0.7f, 0.7f, 0.7f);//hard coded but may be able to adjust size later
+        Destroy(particleObj, duration); //Gets rid of the particles after duration
+
         while (elapsedTime < duration)
         {
             Collider[] colliders = Physics.OverlapSphere(transform.position, radius, layerMask);
@@ -46,7 +48,6 @@ public class MagnetEffectHandler : MonoBehaviour
             elapsedTime += Time.fixedDeltaTime;
             yield return new WaitForFixedUpdate();
         }
-        Destroy(particleObj);//Gets rid of the particles after duration
         Debug.Log("Magnet Effect Ended");
     }
 }


### PR DESCRIPTION
## Changes
- Switched anti-grav ball to purple
- Magnet effect glow will now destroy properly (or close enough)

### Known Bugs/Issues
There will be multiple instances when combining balls that are still using the magnet effect, but unfortunately, particle systems in Unity are themselves buggy. Not sure if there's a fix, but that's the best I can do given Unity's own bad code...
## Testing Scene and Script
Normal Kitchen level for the yellow ball

## Issue ticket number/link
#118, #131

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Make sure I am merging my features into the `develop` branch
- [x] I have notified the other members of the programming team that my task is ready to review
